### PR TITLE
Add text chat and moderation features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# orbital
+# Orbital Chat
+
+Application de chat vidéo aléatoire avec prise en charge d'un chat textuel.
+
+## Nouveaux événements Socket.IO
+
+- `chat:text` : envoi d'un message textuel à son partenaire.
+- `app:banned` : notification de bannissement temporaire après trois signalements.
+
+## Lancer les tests
+
+```bash
+node tests/run-tests.js
+```

--- a/public/index.html
+++ b/public/index.html
@@ -44,6 +44,13 @@
                     <video id="local-video" autoplay muted playsinline></video>
                 </div>
             </div>
+            <div id="text-chat">
+                <div id="chat-messages"></div>
+                <form id="chat-form">
+                    <input id="chat-input" type="text" autocomplete="off" placeholder="Message..." maxlength="200" />
+                    <button type="submit">Envoyer</button>
+                </form>
+            </div>
             <div class="controls">
                 <button id="next-btn">Suivant ➡️</button>
                 <button id="report-btn" class="danger">Signaler 🚩</button>

--- a/public/style.css
+++ b/public/style.css
@@ -99,6 +99,36 @@ body {
     position: relative;
 }
 
+#text-chat {
+    display: flex;
+    flex-direction: column;
+    padding: 0 1rem;
+    overflow-y: auto;
+    max-height: 200px;
+}
+
+#chat-messages {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+}
+
+#chat-form {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+
+#chat-input {
+    flex-grow: 1;
+    padding: 0.5rem;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+    background-color: #2c2c2c;
+    color: var(--text-color);
+}
+
 .video-wrapper {
     background-color: #000;
     border-radius: 12px;
@@ -200,7 +230,8 @@ button {
     border: none;
     border-radius: 8px;
     cursor: pointer;
-    transition: all 0.2s ease;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    transform-origin: center;
     color: #fff;
 }
 
@@ -229,6 +260,11 @@ button.danger:hover {
     color: #fff;
 }
 
+button:hover {
+    transform: scale(1.05);
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
 button:active {
     transform: scale(0.98);
 }
@@ -244,6 +280,33 @@ button:active {
 }
 @keyframes spin {
     to { transform: rotate(360deg); }
+}
+
+/* Chat messages */
+.chat-message {
+    max-width: 70%;
+    padding: 0.8rem;
+    margin: 0.5rem;
+    border-radius: 12px;
+    animation: messageFadeIn 0.3s ease-out;
+    background-color: var(--surface-color);
+}
+
+.chat-message.sent { align-self: flex-end; background-color: var(--primary-color); color: #000; }
+.chat-message.received { align-self: flex-start; }
+
+@keyframes messageFadeIn {
+    from { opacity: 0; transform: translateY(5px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.view-transition {
+    animation: fadeSlide 0.4s ease-out;
+}
+
+@keyframes fadeSlide {
+    0% { opacity: 0; transform: translateY(10px); }
+    100% { opacity: 1; transform: translateY(0); }
 }
 
 /* Responsive */

--- a/tests/moderation.test.js
+++ b/tests/moderation.test.js
@@ -1,0 +1,40 @@
+const assert = require('assert');
+const createHandleReport = require('../utils/moderation');
+
+function mockRedis() {
+  const store = new Map();
+  return {
+    async sAdd(key, value) {
+      if (!store.has(key)) store.set(key, new Set());
+      store.get(key).add(value);
+    },
+    async sCard(key) {
+      return store.has(key) ? store.get(key).size : 0;
+    },
+    async expire(key) {
+      store.set(`${key}:expired`, true);
+    }
+  };
+}
+
+function test(desc, fn) {
+  try { fn(); console.log(`\u2714 ${desc}`); } catch (e) { console.error(`\u2718 ${desc}`); console.error(e); process.exitCode=1; }
+}
+
+const events = [];
+const io = { to: () => ({ emit: (e) => events.push(e) }) };
+const pubClient = mockRedis();
+const handleReport = createHandleReport({ pubClient, io });
+
+(async () => {
+  await handleReport('u1');
+  await handleReport('u1');
+  await new Promise(r => setTimeout(r, 2));
+  test('not banned after two reports', () => {
+    assert.strictEqual(events.length, 0);
+  });
+  await handleReport('u1');
+  test('banned on third report', () => {
+    assert.strictEqual(events.includes('app:banned'), true);
+  });
+})();

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+const path = require('path');
+
+const testFiles = fs.readdirSync(__dirname).filter(f => f.endsWith('.test.js'));
+
+for (const file of testFiles) {
+  require(path.join(__dirname, file));
+}

--- a/tests/sanitize.test.js
+++ b/tests/sanitize.test.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+const sanitize = require('../utils/sanitize');
+
+function test(description, fn) {
+  try {
+    fn();
+    console.log(`\u2714 ${description}`);
+  } catch (e) {
+    console.error(`\u2718 ${description}`);
+    console.error(e);
+    process.exitCode = 1;
+  }
+}
+
+test('removes script tags and trims', () => {
+  const input = '<script>alert(1)</script>hello world';
+  const result = sanitize(input);
+  assert.strictEqual(result, 'hello world');
+});
+
+test('returns empty string for non strings', () => {
+  assert.strictEqual(sanitize(null), '');
+});

--- a/utils/moderation.js
+++ b/utils/moderation.js
@@ -1,0 +1,22 @@
+/**
+ * utils/moderation.js
+ * Basic report handling with automatic temporary ban after three reports.
+ * @param {object} deps - Dependencies
+ * @param {import('redis').RedisClientType} deps.pubClient - Redis client
+ * @param {import('socket.io').Server} deps.io - Socket.IO server
+ * @returns {function(string):Promise<void>}
+ */
+function createHandleReport({ pubClient, io }) {
+    const BAN_DURATION = 3600; // seconds
+    return async function handleReport(reportedUserId) {
+        const baseKey = `orbital:user:${reportedUserId}`;
+        await pubClient.sAdd(`${baseKey}:reports`, Date.now());
+        const count = await pubClient.sCard(`${baseKey}:reports`);
+        if (count >= 3) {
+            await pubClient.expire(baseKey, BAN_DURATION);
+            io.to(reportedUserId).emit('app:banned');
+        }
+    };
+}
+
+module.exports = createHandleReport;

--- a/utils/sanitize.js
+++ b/utils/sanitize.js
@@ -1,0 +1,14 @@
+/**
+ * utils/sanitize.js
+ * Sanitize a string by removing basic XSS patterns and trimming length.
+ * @param {string} input - User provided string
+ * @returns {string} Sanitized string (max 20 chars)
+ */
+const xssPatterns = /<script.*?>.*?<\/script>|on\w+="[^"]*"/gi;
+
+function sanitize(input) {
+    if (typeof input !== 'string') return '';
+    return input.replace(xssPatterns, '').trim().substring(0, 20);
+}
+
+module.exports = sanitize;


### PR DESCRIPTION
## Summary
- implement sanitization utility and moderation handler
- wire text chat and reporting logic into server
- add chat UI and micro-interactions in client
- style chat messages and buttons
- create simple unit tests
- update README with new events and test instructions

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_b_688c82039d5083249c893afa2612f93b