### PR TITLE
Refactor dashboard UI

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -14,9 +14,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const statusOverlay = document.getElementById('status-overlay');
     const statusText = document.getElementById('status-text');
     const videoPlaceholder = document.getElementById('video-placeholder');
-    const partnerPseudoPlaceholder = document.getElementById('partner-pseudo-placeholder');
-    const connectionStatus = document.getElementById('connection-status');
-    const connectionPing = document.getElementById('connection-ping');
+    const dashboardView = document.getElementById('dashboard-view');
+    const dashboardUserPseudo = document.getElementById('dashboard-user-pseudo');
+    const dashboardPartnerInfo = document.getElementById('dashboard-partner-info');
+    let connectionStatus = document.getElementById('connection-status');
+    let connectionPing = document.getElementById('connection-ping');
     const userPseudoDisplay = document.getElementById('user-pseudo');
     
     // Contrôles vidéo
@@ -75,8 +77,12 @@ document.addEventListener('DOMContentLoaded', () => {
             statusOverlay.classList.remove('hidden');
             videoPlaceholder.classList.add('hidden');
             remoteVideo.style.display = 'none';
-            connectionStatus.innerHTML = '<i class="fas fa-circle-notch fa-spin"></i> Connexion en cours';
-            connectionPing.textContent = '';
+            if (connectionStatus) {
+                connectionStatus.innerHTML = '<i class="fas fa-circle-notch fa-spin"></i> Connexion en cours';
+            }
+            if (connectionPing) {
+                connectionPing.textContent = '';
+            }
         },
         
         showConnected(partnerData) {
@@ -85,13 +91,19 @@ document.addEventListener('DOMContentLoaded', () => {
             
             const { pseudo, country } = partnerData;
             const tooltip = country.name ? `En direct de ${country.name}` : "D'origine inconnue";
-            
-            partnerPseudoPlaceholder.innerHTML = `
-                ${pseudo}
-                <span class="country-badge" data-tooltip="${tooltip}">${country.emoji}</span>
+
+            dashboardPartnerInfo.innerHTML = `
+                <h4>Partenaire</h4>
+                <p id="partner-pseudo-placeholder">${pseudo} <span class="country-badge" data-tooltip="${tooltip}">${country.emoji}</span></p>
+                <div class="connection-info">
+                    <span id="connection-status"><i class="fas fa-circle-check"></i> Connecté</span>
+                    <span id="connection-ping"></span>
+                </div>
             `;
-            
-            connectionStatus.innerHTML = '<i class="fas fa-circle-check"></i> Connecté';
+
+            // Mettre à jour les références après insertion
+            connectionStatus = document.getElementById('connection-status');
+            connectionPing = document.getElementById('connection-ping');
             
             if (window.gsap) {
                 gsap.from('.country-badge', { 
@@ -116,6 +128,7 @@ document.addEventListener('DOMContentLoaded', () => {
             statusText.textContent = 'Partenaire déconnecté. Recherche en cours...';
             connectionStatus.innerHTML = '<i class="fas fa-circle-notch fa-spin"></i> Recherche en cours';
             connectionPing.textContent = '';
+            dashboardPartnerInfo.innerHTML = '';
             stopPing();
             cleanupConnection();
         },
@@ -320,7 +333,7 @@ document.addEventListener('DOMContentLoaded', () => {
         
         remoteVideo.style.display = 'none';
         videoPlaceholder.classList.remove('hidden');
-        partnerPseudoPlaceholder.textContent = '';
+        dashboardPartnerInfo.innerHTML = '';
         currentPartnerId = null;
         
         chatUI.clearMessages();
@@ -398,6 +411,8 @@ document.addEventListener('DOMContentLoaded', () => {
             // Basculer vers la vue chat
             loginView.classList.add('hidden');
             chatView.classList.remove('hidden');
+            dashboardView.classList.remove('hidden');
+            dashboardUserPseudo.textContent = pseudo;
             
             // Initialiser la connexion Socket.IO
             initializeSocket();

--- a/public/index.html
+++ b/public/index.html
@@ -51,6 +51,27 @@
             </div>
         </div>
 
+        <!-- Tableau de Bord -->
+        <div id="dashboard-view" class="hidden">
+            <div id="dashboard-user-profile">
+                <span id="dashboard-user-pseudo"></span>
+            </div>
+            <div id="dashboard-partner-info"></div>
+            <div id="dashboard-controls">
+                <button id="next-btn" class="btn-primary">
+                    <i class="fas fa-random"></i>
+                    <span>Suivant</span>
+                </button>
+                <button id="report-btn" class="btn-danger">
+                    <i class="fas fa-flag"></i>
+                    <span>Signaler</span>
+                </button>
+                <button id="settings-btn" class="btn-secondary" title="Paramètres">
+                    <i class="fas fa-cog"></i>
+                </button>
+            </div>
+        </div>
+
         <!-- Vue du chat -->
         <div id="chat-view" class="hidden">
             <div class="videos-container">
@@ -68,13 +89,6 @@
                     <div id="video-placeholder" class="placeholder">
                         <div class="placeholder-icon">
                             <i class="fas fa-user-astronaut"></i>
-                        </div>
-                        <div class="partner-info">
-                            <p id="partner-pseudo-placeholder"></p>
-                            <div class="connection-info">
-                                <span id="connection-status"><i class="fas fa-circle-notch fa-spin"></i> Connexion en cours</span>
-                                <span id="connection-ping"></span>
-                            </div>
                         </div>
                     </div>
                     
@@ -113,19 +127,7 @@
                 </form>
             </div>
             
-            <div class="controls">
-                <button id="next-btn" class="btn-primary">
-                    <i class="fas fa-random"></i>
-                    <span>Suivant</span>
-                </button>
-                <button id="report-btn" class="btn-danger">
-                    <i class="fas fa-flag"></i>
-                    <span>Signaler</span>
-                </button>
-                <button id="settings-btn" class="btn-secondary" title="Paramètres">
-                    <i class="fas fa-cog"></i>
-                </button>
-            </div>
+
         </div>
         
         <!-- Modal Paramètres -->

--- a/public/style.css
+++ b/public/style.css
@@ -26,8 +26,14 @@
     padding: 0;
 }
 
+.hidden {
+    display: none !important;
+}
+
 body {
-    font-family: 'Inter', sans-serif;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                 Helvetica, Arial, sans-serif, "Apple Color Emoji",
+                 "Segoe UI Emoji", "Segoe UI Symbol";
     background-color: var(--bg-color);
     color: var(--text-color);
     display: flex;
@@ -111,6 +117,40 @@ body {
     outline: none;
     border-color: var(--primary-color);
     box-shadow: 0 0 0 3px rgba(187, 134, 252, 0.25);
+}
+
+/* --- Tableau de bord --- */
+#dashboard-view {
+    width: 100%;
+    max-width: 500px;
+    background-color: var(--surface-color);
+    display: flex;
+    flex-direction: column;
+    padding: 1rem;
+    border-right: 1px solid var(--border-color);
+}
+
+#dashboard-user-profile,
+#dashboard-partner-info {
+    padding: 1rem;
+    border-bottom: 1px solid var(--border-light);
+    margin-bottom: 1rem;
+}
+
+#dashboard-user-profile h4,
+#dashboard-partner-info h4 {
+    margin-bottom: 0.5rem;
+}
+
+#dashboard-controls {
+    margin-top: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+#dashboard-controls button {
+    width: 100%;
 }
 
 #join-btn {
@@ -695,7 +735,7 @@ video {
         right: 1rem;
     }
     
-    .controls {
+    #dashboard-controls {
         padding: 0.8rem;
     }
     


### PR DESCRIPTION
## Summary
- add global `.hidden` class and emoji font fallbacks
- create dashboard panel in `index.html`
- move main controls into dashboard
- rewrite UI logic to populate dashboard
- style dashboard panel with flex layout

## Testing
- `node tests/run-tests.js` *(fails: `pubClient.zAdd is not a function`)*

------
https://chatgpt.com/codex/tasks/task_b_688cb8621aac8324b7bc08b2783d2a78