### PR TITLE
Add auto login with localStorage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -66,6 +66,9 @@
                     <i class="fas fa-flag"></i>
                     <span>Signaler</span>
                 </button>
+                <button id="logout-btn" class="btn-secondary" title="Changer de pseudo">
+                    <i class="fas fa-sign-out-alt"></i>
+                </button>
                 <button id="settings-btn" class="btn-secondary" title="Paramètres">
                     <i class="fas fa-cog"></i>
                 </button>


### PR DESCRIPTION
## Summary
- save user pseudo in localStorage
- reuse join logic in `startJoin`
- auto reconnect when a pseudo is saved
- add logout button in dashboard

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_b_688cc56eb8288324bdbb742184fc82d5