### PR TITLE
Security fixes and config cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+PORT=3000
+REDIS_URL=redis://localhost:6379
+ALLOWED_ORIGINS=http://localhost:3000
+REDIS_TLS=false

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "express-rate-limit": "^8.0.1",
         "geoip-lite": "^1.4.2",
         "helmet": "^8.1.0",
+        "dotenv": "^16.3.1",
         "redis": "^4.7.1",
         "socket.io": "^4.8.1",
         "socket.io-redis": "^6.1.1"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "express-rate-limit": "^8.0.1",
     "geoip-lite": "^1.4.2",
     "helmet": "^8.1.0",
+    "dotenv": "^16.3.1",
     "redis": "^4.7.1",
     "socket.io": "^4.8.1",
     "socket.io-redis": "^6.1.1"

--- a/public/client.js
+++ b/public/client.js
@@ -287,13 +287,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // 5. Configuration WebRTC
     const rtcConfig = {
         iceServers: [
-            // Serveur TURN - À remplacer par votre configuration
-            { 
-                urls: 'turn:your-turn-server.com:3478',
-                username: 'username',
-                credential: 'password'
-            },
-            // Serveurs STUN publics
+            // TODO: Les identifiants du serveur TURN doivent être récupérés
+            // de manière dynamique et sécurisée depuis le serveur.
+            { urls: 'turn:your-turn-server.com:3478' },
             { urls: 'stun:stun.l.google.com:19302' },
             { urls: 'stun:stun1.l.google.com:19302' },
             { urls: 'stun:stun2.l.google.com:19302' }

--- a/public/index.html
+++ b/public/index.html
@@ -134,7 +134,7 @@
         </div>
         
         <!-- Modal Paramètres -->
-        <div id="settings-modal" class="modal hidden">
+        <div id="settings-modal" class="modal">
             <div class="modal-content">
                 <div class="modal-header">
                     <h3>Paramètres</h3>

--- a/server.js
+++ b/server.js
@@ -1,11 +1,17 @@
-// server.js - Version 3.0 (Ultimate - Sans dotenv)
+// server.js - Version 3.0
 
-// 1. Configuration manuelle des variables d'environnement
+// Chargement des variables d'environnement
+try {
+  require('dotenv').config();
+} catch (err) {
+  console.warn('dotenv not installed, skipping configuration file load');
+}
+
 const config = {
-  PORT: 3000, // Port par défaut
-  REDIS_URL: 'redis://localhost:6379', // URL Redis par défaut
-  ALLOWED_ORIGINS: 'http://localhost:3000', // Origines autorisées
-  REDIS_TLS: false // TLS désactivé par défaut
+  PORT: process.env.PORT || 3000,
+  REDIS_URL: process.env.REDIS_URL || 'redis://localhost:6379',
+  ALLOWED_ORIGINS: process.env.ALLOWED_ORIGINS || 'http://localhost:3000',
+  REDIS_TLS: process.env.REDIS_TLS === 'true'
 };
 
 // 2. Imports
@@ -112,10 +118,10 @@ async function getGeoData(ip, pubClient) {
 }
 
 // Création des clients Redis
-const pubClient = createClient({ 
+const pubClient = createClient({
     url: config.REDIS_URL,
     socket: {
-        tls: config.REDIS_TLS === 'true',
+        tls: config.REDIS_TLS,
         rejectUnauthorized: false
     }
 });

--- a/tests/sanitize.test.js
+++ b/tests/sanitize.test.js
@@ -12,10 +12,10 @@ function test(description, fn) {
   }
 }
 
-test('removes script tags and trims', () => {
+test('escapes html and trims', () => {
   const input = '<script>alert(1)</script>hello world';
   const result = sanitize(input);
-  assert.strictEqual(result, 'hello world');
+  assert.strictEqual(result, '&lt;script&gt;alert(1)&lt;/script&gt;hello world');
 });
 
 test('returns empty string for non strings', () => {

--- a/utils/sanitize.js
+++ b/utils/sanitize.js
@@ -4,39 +4,21 @@
  * @param {string} input - User provided string
  * @returns {string} Sanitized string
  */
-const xssPatterns = [
-    /<script.*?>.*?<\/script>/gi, // Script tags
-    /on\w+="[^"]*"/gi, // Event handlers
-    /javascript:[^"']*/gi, // JavaScript URLs
-    /eval\(.*?\)/gi, // eval()
-    /expression\(.*?\)/gi // CSS expressions
-];
-
-const emojiRegex = /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F700}-\u{1F77F}\u{1F780}-\u{1F7FF}\u{1F800}-\u{1F8FF}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{2B50}\u{1F004}\u{1F0CF}\u{1F18E}\u{1F191}-\u{1F19A}\u{1F1E6}-\u{1F1FF}]/gu;
-
+// Simplified sanitization preserving emoji order
 function sanitize(input) {
     if (typeof input !== 'string') return '';
-    
-    // Conserver les emojis
-    const emojis = input.match(emojiRegex) || [];
-    
-    // Nettoyer le texte
+
     let clean = input;
-    xssPatterns.forEach(pattern => {
-        clean = clean.replace(pattern, '');
-    });
-    
+
     // Échapper les balises HTML
     clean = clean.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    
+
+    // Supprimer les schémas JavaScript
+    clean = clean.replace(/javascript:/gi, '');
+
     // Limiter la longueur et trim
     clean = clean.trim().substring(0, 200);
-    
-    // Réinsérer les emojis (simplifié)
-    if (emojis.length > 0) {
-        clean += ' ' + emojis.join(' ');
-    }
-    
+
     return clean;
 }
 


### PR DESCRIPTION
## Summary
- remove hard coded TURN credentials in the client
- make settings modal visible when opening
- load configuration from environment variables using dotenv
- provide example `.env` file
- simplify sanitize logic and update tests

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_b_688cc7b022e88324a29f7b36b7bebbcf